### PR TITLE
Improve local tarball resolution speed

### DIFF
--- a/task/resolveTarball.js
+++ b/task/resolveTarball.js
@@ -38,9 +38,24 @@ function getPkgJson (pkgPath) {
 }
 
 function getPkgPath (dep) {
-  return glob.sync('node_modules/**/' + dep.name + '/package.json', {
-    realpath: true
-  })[0] || '';
+  var depPackagePath = "node_modules/" + dep.name + "/package.json";
+  var result = '';
+  
+  try {
+    // Assume the file is directly located at the top of /node_modules, in
+    // which case we can just access it directly.
+    fs.accessSync(depPackagePath, fs.F_OK);
+    result = fs.realpathSync(depPackagePath);
+  } 
+  catch (e) {
+    // It isn't accessible directly.  Perhaps the package is nested somewhere
+    // under /node_modules, so we'll need to do a deeper search.
+    result = glob.sync('node_modules/**/' + dep.name + '/package.json', {
+      realpath: true
+    })[0] || '';
+  }
+  
+  return result;
 }
 
 function resolveRemotely (dep) {


### PR DESCRIPTION
Attempts to fix #32 .

glob.sync() appears to be very slow, probably because it's doing a
bunch of file searching.  We know the package name, so we can try doing
a direct path lookup first.  If that fails, then we can fall back to
doing a recursive search using glob.
