### PR TITLE
Use synchronous globbing of npm 2 packages

### DIFF
--- a/task/resolveTarball/resolveLocally/npm2.js
+++ b/task/resolveTarball/resolveLocally/npm2.js
@@ -18,17 +18,9 @@ function getPkgPathNpm2 (dep) {
 function buildIndex (dep, done) {
   console.info(chalk.gray('? indexing package.json files... (not needed in npm3+)'), dep.id);
   return new Promise(function (resolve) {
-    glob('node_modules/**/package.json', onGlob);
-
-    function onGlob (err, files) {
-      if (err) {
-        pkgPathByName = {};
-        resolve();
-      } else {
-        pkgPathByName = files.reduce(addPathToIndex, {});
-        resolve();
-      }
-    }
+    var files = glob.sync('node_modules/**/package.json');
+    pkgPathByName = files.reduce(addPathToIndex, {});
+    resolve();
 
     function addPathToIndex (index, pkgPath) {
       var name = pkgPath.replace('/package.json', '').replace(/.*\//, '');


### PR DESCRIPTION
As mentioned in #32, it looks like `glob.sync` uses significantly less memory than the async `glob`, and it should be faster as well.

The changes in 28a1bdbf2b803e77027f5aa5840fadeff516345f did a lot to improve lookup performance, but the swap from sync to async should be safe to revert.

I'll see if I can whip up some benchmarks to show the difference.
