### PR TITLE
Allow shrinkpacking without shrinkwrapping in-between

### DIFF
--- a/task/init/index.js
+++ b/task/init/index.js
@@ -49,8 +49,7 @@ function getGraph (graphPath) {
   }
   var source = fs.readFileSync(graphPath, 'utf8');
   if (source.indexOf('node_shrinkwrap/') !== -1) {
-    console.error(chalk.red('! npm-shrinkwrap.json is already shrinkpacked, update it using `npm shrinkwrap --dev` then try again'));
-    process.exit(1);
+    console.warn(chalk.yellow('! npm-shrinkwrap.json is already shrinkpacked, you may want to update it using `npm shrinkwrap --dev` before shrinkpacking'));
   }
   return JSON.parse(source);
 }


### PR DESCRIPTION
Me and @valscion were wondering whether it really is necessary to run `npm shrinkwrap` before `shrinkpack`, as the current error message claims.

We tried changing it to a warning, and at least in our case everything seems to work fine. If there are no changes to be made, `shrinkpack` just won't do anything.

```
$ shrinkpack
! npm-shrinkwrap.json is already shrinkpacked, you may want to update it using `npm shrinkwrap --dev` before shrinkpacking
i 1234 dependencies in npm-shrinkwrap.json
i 0 have a missing "resolved" property
i 0 need removing from ./node_shrinkwrap
i 0 need adding to ./node_shrinkwrap
i 0 your npm cache
i 0 need downloading
shrinkpack +0 -0 ↓0 ✓0 00:00
```

Do you know of any situations where running shrinkpack on an already shrinkpacked project would cause problems?

This essentially fixes #31.
