### PR TITLE
feat(shrinkwrap): support private/scoped packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ node_modules
 .lock-wscript
 
 npm-debug.log
+
+# Testing artifacts
+test/sinopia/storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,4 @@ services:
                 environment:
                         NPM_VERSION: 3.8.7
                 links:
-                        - npm_registry
-
+                        - npm_registry:secure_registry

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '2'
+services:
+        npm_registry:
+                image: rnbwd/sinopia
+                volumes:
+                        - ./test/sinopia/storage:/sinopia/sinopia/storage
+                        - ./test/sinopia/config.yaml:/sinopia/sinopia/config.yaml
+                expose:
+                        - "4873"
+        tests:
+                build: .
+                environment:
+                        NPM_VERSION: 3.8.7
+                links:
+                        - npm_registry
+

--- a/package.json
+++ b/package.json
@@ -68,6 +68,6 @@
     "commit-release": "commit-release",
     "lint": "semistandard --format",
     "build-tests": "docker build -t shrinkpack-tests .",
-    "test": "docker run --rm -e NPM_VERSION=3.9.5 shrinkpack-tests"
+    "test": "docker-compose run --rm -e NPM_VERSION=3.9.5 tests"
   }
 }

--- a/src/addToCache.js
+++ b/src/addToCache.js
@@ -12,7 +12,7 @@ function addToCache (deps) {
 
 function cachePackage (dep) {
   console.info(chalk.yellow('↓ %s from %s'), dep.id, dep.shrinkwrap.resolved);
-  return shell('npm cache add ' + dep.shrinkwrap.resolved)
+  return shell('npm cache --scope=' + dep.scope + ' add ' + dep.shrinkwrap.resolved)
     .catch(fail);
 
   function fail (err) {

--- a/src/init/readGraph/index.js
+++ b/src/init/readGraph/index.js
@@ -22,6 +22,7 @@ function readGraph (graph, pathToBundle, npmCachePath) {
       bundle: getShrinkwrapEntry(name, meta),
       id: name + '@' + meta.version,
       name: name,
+      scope: getPackageScope(name),
       shrinkwrap: meta,
       tarball: {
         shrinkpack: getShrinkpackPath(name, meta),
@@ -44,5 +45,10 @@ function readGraph (graph, pathToBundle, npmCachePath) {
 
   function getTarballName (name, version) {
     return name.replace(/\//g, '-') + '-' + version + '.tgz';
+  }
+
+  function getPackageScope (name) {
+    var scope = name.substring(0, name.indexOf('/'));
+    return (scope !== name) ? scope : '';
   }
 }

--- a/test/package.json
+++ b/test/package.json
@@ -6,7 +6,8 @@
     "express": "git+https://git@github.com/visionmedia/express.git",
     "finch": "1.3.11",
     "os-locale": "sindresorhus/os-locale",
-    "wowsuch": "github:swirlycheetah/wowsuch"
+    "wowsuch": "github:swirlycheetah/wowsuch",
+    "@telerik/eslint-config": "1.1.0"
   },
   "private": true
 }

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -11,6 +11,12 @@ function header() {
 npm config set loglevel error --global
 npm config set registry http://npm_registry:4873
 
+npm login --scope=@telerik --registry=http://secure_registry:4873 <<!
+shrinkpack
+shrinkpack
+shrinkpack@example.com
+!
+
 header "install npm@$NPM_VERSION"
 npm install -g npm@$NPM_VERSION
 INSTALLED_NPM_VERSION="$(npm --version)"
@@ -37,10 +43,19 @@ npm install
 
 header "shrinkpacked project: shrinkwrap"
 npm shrinkwrap --dev
+CONTROL_SHRINKWRAP="$(cat npm-shrinkwrap.json)"
 
 header "shrinkpacked project: shrinkpack"
 node /usr/src/shrinkpack/cli.js
+ON_SHRINKPACK_SHRINKWRAP="$(cat npm-shrinkwrap.json)"
 ON_SHRINKPACK_RUN="$(find ./node_modules | sort)"
+
+if [ "$ON_SHRINKPACK_SHRINKWRAP" == "$CONTROL_SHRINKWRAP" ]; then
+  header "failed: running shrinkpack doesn't change shrinkwrap file"
+  exit 1
+else
+  header "√ running shrinkpack updates the shrinkwrap file"
+fi
 
 if [ "$ON_SHRINKPACK_RUN" != "$CONTROL_INSTALLATION" ]; then
   header "failed: running shrinkpack changes installation"

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -9,6 +9,7 @@ function header() {
 }
 
 npm config set loglevel error --global
+npm config set registry http://npm_registry:4873
 
 header "install npm@$NPM_VERSION"
 npm install -g npm@$NPM_VERSION

--- a/test/sinopia/config.yaml
+++ b/test/sinopia/config.yaml
@@ -21,7 +21,7 @@ uplinks:
 packages:
   '@*/*':
     # scoped packages
-    access: $all
+    access: $authenticated
     publish: $authenticated
     proxy: npmjs
 

--- a/test/sinopia/config.yaml
+++ b/test/sinopia/config.yaml
@@ -1,0 +1,49 @@
+#
+# Other config file examples:
+# https://github.com/rlidwka/sinopia/tree/master/conf
+#
+
+# path to a directory with all packages
+storage: ./storage
+
+auth:
+  htpasswd:
+    file: ./htpasswd
+    # Maximum amount of users allowed to register, defaults to "+inf".
+    # You can set this to -1 to disable registration.
+    #max_users: 1000
+
+# a list of other known repositories we can talk to
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+
+packages:
+  '@*/*':
+    # scoped packages
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+
+  '*':
+    # allow all users (including non-authenticated users) to read and
+    # publish all packages
+    #
+    # you can specify usernames/groupnames (depending on your auth plugin)
+    # and three keywords: "$all", "$anonymous", "$authenticated"
+    access: $all
+
+    # allow all known users to publish packages
+    # (anyone can register by default, remember?)
+    publish: $authenticated
+
+    # if package is not available locally, proxy requests to 'npmjs' registry
+    proxy: npmjs
+
+listen:
+  - 0.0.0.0:4873
+
+# log settings
+logs:
+  - {type: stdout, format: pretty, level: http}
+  #- {type: file, path: sinopia.log, level: info}


### PR DESCRIPTION
Hey thanks for an awesome package:

This PR adds support for scoped / private npm packages. 

Just for background: I was trying to use shrinkpack to solve issues with containerising my Node deployments without needing to include an authentication token in the image or manually copying over the node_modules folder (which totally isn't safe).

Currently if we try to shrinkpack dependencies that are on a private registry, shrinkwrap will fail to add them to the cache with a 401. This PR just adds the `--scope=[scope]` [flag](https://docs.npmjs.com/misc/config#scope) to the `npm cache add` command so npm will include the credentials in it's request. Surprising that this wasn't already the case.

I wasn't sure how we could add a test into place for this, as we'd almost need a private registry to test this against. Since you're now using docker, we could potentially add https://www.npmjs.com/package/sinopia and test against that as well.

Look forward to your feedback
