### PR TITLE
docs(dependencies): add docker image build step

### DIFF
--- a/DEPENDENCIES.md
+++ b/DEPENDENCIES.md
@@ -15,6 +15,7 @@ npm install shrinkpack --save
 
 ```sh
 npm install
+npm run build-tests
 npm test
 ```
 


### PR DESCRIPTION
Noticed that the dependencies.md docs missed a step in running the tests. You might think about adding a contributors.md file to just have all the stuff around style, etc. for this project in the one place :)
