### PR TITLE
fix(npm5): accept package-lock and fix integrity rewrites

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,8 +68,7 @@ export const shrinkpack: Shrinkpack = async ({ decompress = true, projectPath = 
   };
 
   const rehashPackage = async (pkg: IPackage): Promise<IPackage> => {
-    const integrity = await getIntegrity(getArchivePath(pkg));
-    pkg.node.integrity = integrity.toJSON();
+    pkg.node.integrity += ' ' + await getIntegrity(getArchivePath(pkg))
     return pkg;
   };
 
@@ -90,7 +89,7 @@ export const shrinkpack: Shrinkpack = async ({ decompress = true, projectPath = 
   const lockfile = await locate(projectPath);
 
   if (lockfile === null) {
-    error('npm-shrinkwrap.json is missing, create it using `npm shrinkwrap` then try again');
+    error('no package-lock.json or npm-shrinkwrap.json found. Please install using npm@5 or later, or run `npm shrinkwrap` to generate one.');
     process.exit(1);
     return;
   }

--- a/src/lib/lockfile.ts
+++ b/src/lib/lockfile.ts
@@ -41,7 +41,7 @@ export const getFragments = (lockfile: IShrinkwrapFragment): IFragment[] =>
 export const getPackages = (lockfile: IShrinkwrap): IPackage[] => toArray<IShrinkwrap, IPackage>(lockfile);
 
 export const locate = async (projectPath: string): Promise<ILockfilePointer | null> => {
-  const lockfiles = ['npm-shrinkwrap.json'];
+  const lockfiles = ['npm-shrinkwrap.json', 'package-lock.json'];
   const getPath = (name: string) => join(projectPath, name);
   const getPointer = async (path: string) => ({ data: await read(path), filePath: path });
   const hasData = (pointer: ILockfilePointer) => pointer.data !== null;


### PR DESCRIPTION
this should get everything working once the corresponding changes land in npm. You won't be able to test it yet 'cause I don't have a standalone branch of npm you can try out, but I'm putting this up so you can see the expected changes and start reviewing them. It's probably safe enough to land this in your dev branch anyway, though.